### PR TITLE
Replaces `npm ci` with `npm install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /kutt
 # download dependencies while using Docker's caching
 RUN --mount=type=bind,source=package.json,target=package.json \
     --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev
+    npm install --omit=dev
 
 RUN mkdir -p /var/lib/kutt
 


### PR DESCRIPTION
Switches from `npm ci` to `npm install` in the Dockerfile.

This change ensures that dependencies are installed even if `package-lock.json` is not perfectly synchronized, which can happen in certain CI/CD environments. Using `npm install` provides a more robust and reliable dependency installation process.